### PR TITLE
Add RTTI-Support

### DIFF
--- a/analyse_binary.py
+++ b/analyse_binary.py
@@ -21,6 +21,7 @@ def main():
     database = Database()
     print 'Strings:', len(database.strings)
     print 'Functions:', len(database.functions)
+    print 'RTTI Classes:', len(database.classes)
     database.save(file_path)
 
 

--- a/gcc.py
+++ b/gcc.py
@@ -1,0 +1,204 @@
+
+import idaapi
+from idaapi import BADADDR
+from idc import *
+
+from utils import utils
+u = utils()
+
+all_classes = {}
+
+ti_names = [
+ "St9type_info",
+ "N10__cxxabiv117__class_type_infoE",
+ "N10__cxxabiv120__si_class_type_infoE",
+ "N10__cxxabiv121__vmi_class_type_infoE",
+]
+
+TI_TINFO = 0
+TI_CTINFO = 1
+TI_SICTINFO = 2
+TI_VMICTINFO = 3
+
+class BaseClass:
+    def __init__(self, ti, offset, flags):
+        self.ti = ti
+        self.offset = offset
+        self.flags = flags
+
+class ClassDescriptor:
+    def __init__(self, vtable, namestr):
+        self.vtable = vtable
+        self.namestr = namestr
+        self.bases = []
+
+    def add_base(self, base, offset=0, flags=0):
+        self.bases.append(BaseClass(base, offset, flags))
+
+def tinfo2class(tiname):
+  s = Demangle(tiname, 0)
+  if s is None:
+      return s
+  return s.replace("`typeinfo for'","")
+
+def classname(namestr):
+  return tinfo2class("__ZTI" + namestr)
+
+# dd `vtable for'std::type_info+8
+# dd `typeinfo name for'std::type_info
+def format_type_info(ea):
+  # get the class name string
+  tis = u.get_ptr(ea + u.PTR_SIZE)
+  if u.is_bad_addr(tis):
+    return BADADDR
+  name = GetString(tis)
+  if name == None or len(name) == 0:
+    return BADADDR
+  # looks good, let's do it
+  ea2 = u.format_struct(ea, "vp")
+  u.force_name(tis, "__ZTS" + name)
+  u.force_name(ea, "__ZTI" + name)
+  # find our vtable
+  # 0 followed by ea
+  pat = u.ptr_to_bytes(0) + " " + u.ptr_to_bytes(ea)
+  vtb = FindBinary(0, SEARCH_CASE|SEARCH_DOWN, pat)
+  if not u.is_bad_addr(vtb):
+    u.format_struct(vtb, "pp")
+    u.force_name(vtb, u.vtname(name))
+  else:
+    vtb = BADADDR
+  all_classes[ea] = ClassDescriptor(vtb, name)
+  return ea2
+
+# dd `vtable for'__cxxabiv1::__si_class_type_info+8
+# dd `typeinfo name for'MyClass
+# dd `typeinfo for'BaseClass
+def format_si_type_info(ea):
+  ea2 = format_type_info(ea)
+  pbase = u.get_ptr(ea2)
+  all_classes[ea].add_base(pbase)
+  ea2 = u.format_struct(ea2, "p")
+  return ea2
+
+# dd `vtable for'__cxxabiv1::__si_class_type_info+8
+# dd `typeinfo name for'MyClass
+# dd flags
+# dd base_count
+# (base_type, offset_flags) x base_count
+def format_vmi_type_info(ea):
+  ea2 = format_type_info(ea)
+  ea2 = u.format_struct(ea2, "ii")
+  base_count = Dword(ea2-4)
+  clas = all_classes[ea]
+  if base_count > 100:
+    return BADADDR
+  for i in range(base_count):
+    base_ti = u.get_ptr(ea2)
+    flags_off = u.get_ptr(ea2 + u.PTR_SIZE)
+    off = u.SIGNEXT(flags_off>>8, 24)
+    clas.add_base(base_ti, off, flags_off & 0xFF)
+    ea2 = u.format_struct(ea2, "pl")
+  return ea2
+
+def find_type_info(idx):
+  name = ti_names[idx]
+  ea = u.find_string(name)
+  if ea != BADADDR:
+    xrefs = u.xref_or_find(ea)
+    if xrefs:
+      ti_start = xrefs[0] - u.PTR_SIZE
+      if not u.is_bad_addr(ti_start):
+        ea2 = format_type_info(ti_start)
+        if idx >= TI_CTINFO:
+          u.format_struct(ea2, "p")
+
+def handle_classes(idx, formatter):
+  name = u.vtname(ti_names[idx])
+  ea = LocByName(name)
+  if ea == BADADDR:
+    # try single underscore
+    name = name[1:]
+    ea = LocByName(name)
+  if ea == BADADDR:
+    return
+  idx = 0
+  handled = set()
+  while ea != BADADDR:
+    if idaapi.is_spec_ea(ea):
+      xrefs = u.xref_or_find(ea, True)
+      ea += u.PTR_SIZE*2
+      xrefs.extend(u.xref_or_find(ea, True))
+    else:
+      ea += u.PTR_SIZE*2
+      xrefs = u.xref_or_find(ea, True)
+    for x in xrefs:
+      if not u.is_bad_addr(x) and not x in handled:
+        ea2 = formatter(x)
+        handled.add(x)
+    ea = LocByName("%s_%d" % (name, idx))
+    idx += 1
+
+def findMethods(addr):
+    func = 0
+    methodsCount = 0
+    functions = []
+    while (1):
+        func = u.get_ptr(addr)
+        funcname = GetFunctionName(func)
+        if(funcname == "None"):
+            break
+        if(funcname == "__cxa_pure_virtual"):
+            methodsCount += 1
+            addr += u.PTR_SIZE
+            functions.append(funcname)
+            continue
+        if (func != 0):
+            seg = ida_segment.getseg(func)
+            if (not seg) or (seg.perm & ida_segment.SEGPERM_EXEC) == 0:
+                break
+
+        functions.append(Demangle(funcname, 0))
+        methodsCount += 1
+        addr += u.PTR_SIZE
+
+    # Now lets remove ending zeroes.
+    while (methodsCount):
+        addr -= u.PTR_SIZE
+        func = u.get_ptr(addr)
+        if (func != 0):
+            break
+        methodsCount -= 1
+
+    return functions
+
+def run_gcc():
+    classes = {}
+    # turn on GCC3 demangling
+    idaapi.cvar.inf.demnames |= idaapi.DEMNAM_GCC3
+    find_type_info(TI_TINFO)
+    find_type_info(TI_CTINFO)
+    find_type_info(TI_SICTINFO)
+    find_type_info(TI_VMICTINFO)
+    handle_classes(TI_CTINFO, format_type_info)
+    handle_classes(TI_SICTINFO, format_si_type_info)
+    handle_classes(TI_VMICTINFO, format_vmi_type_info)
+    for i in xrange(len(all_classes)):
+        tiaddr = u.num2key(all_classes)[i]
+        klass = all_classes[tiaddr]
+        name = classname(klass.namestr)
+        ti = "%08X" % tiaddr
+        vt = "%08X" % klass.vtable
+        methods = findMethods(klass.vtable + u.PTR_SIZE*2)
+        basestr = []
+        for b in klass.bases:
+            if b.ti in all_classes:
+                bklass = all_classes[b.ti]
+                basename = classname(bklass.namestr)
+            elif idaapi.is_spec_ea(b.ti):
+                nm = Name(b.ti)
+                basename = tinfo2class(nm)
+            else:
+                basename = "ti_%08X" % b.ti
+            basestr.append(basename)
+        classes[name] = methods
+    return classes

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,219 @@
+import idaapi
+import struct
+from idaapi import get_segm_by_name, hasRef, getFlags, opinfo_t, refinfo_t,\
+get_32bit, get_64bit, get_imagebase, get_byte
+import idautils
+from idautils import DataRefsTo
+from idc import *
+
+# Segments
+within = lambda x, rl: any([True for r in rl if r[0]<=x<=r[1]])
+
+class utils(object):
+    text = 0
+    data = 0
+    rdata = 0
+    valid_ranges = []
+    within = lambda self, x, rl: any([True for r in rl if r[0]<=x<=r[1]])
+
+    REF_OFF = 0
+    x64 = 0
+    PTR_TYPE = 0
+    PTR_SIZE = 0
+
+    def __init__(self):
+        self.text = get_segm_by_name(".text")
+        self.data = get_segm_by_name(".data")
+        self.rdata = get_segm_by_name(".rdata")
+        # try to use rdata if there actually is an rdata segment, otherwise just use data
+        if self.rdata is not None:
+            self.valid_ranges = [(self.rdata.startEA, self.rdata.endEA), (self.data.startEA, self.data.endEA)]
+        else :
+            if(self.data is None):
+                #MacOS support
+                self.data = get_segm_by_name("__data")
+            self.valid_ranges = [(self.data.startEA, self.data.endEA)]
+
+        self.x64 = (idaapi.getseg(here()).bitness == 2)
+        if self.x64:
+            self.PTR_TYPE = FF_QWRD
+            self.REF_OFF = REF_OFF64
+            self.PTR_SIZE = 8
+            self.get_ptr = get_64bit
+        else:
+            self.PTR_TYPE = FF_DWRD
+            self.REF_OFF = REF_OFF32
+            self.PTR_SIZE = 4
+            self.get_ptr = get_32bit
+
+# for 32-bit binaries, the RTTI structs contain absolute addresses, but for
+# 64-bit binaries, they're offsets from the image base.
+    def x64_imagebase(self):
+        if self.x64:
+            return get_imagebase()
+        else:
+            return 0
+
+    def mt_rva(self):
+        ri = refinfo_t()
+        ri.flags = self.REF_OFF
+        ri.target = 0
+        mt = opinfo_t()
+        mt.ri = ri
+        return mt
+
+    def mt_address(self):
+        ri = refinfo_t()
+        ri.flags = self.REF_OFF
+        ri.target = 0
+        mt = opinfo_t()
+        mt.ri = ri
+        return mt
+
+    def mt_ascii(self):
+        ri = refinfo_t()
+        ri.flags = ASCSTR_C
+        ri.target = -1
+        mt = opinfo_t()
+        mt.ri = ri
+        return mt
+
+    def get_strlen(self, addr):
+        strlen = 0
+        while get_byte(addr+strlen) != 0x0 and strlen < 50:
+            strlen+=1
+        #assume no names will ever be longer than 50 bytes
+        if strlen == 50:
+            return None
+        return strlen
+
+    def isVtable(self, addr):
+        function = self.get_ptr(addr)
+        # Check if vtable has ref and its first pointer lies within code segment
+        if hasRef(getFlags(addr)) and function >= self.text.startEA and function <= self.text.endEA:
+            return True
+        return False
+
+# helper for bin search
+    def ptr_to_bytes(self, val):
+      if self.x64:
+        sv = struct.pack("<Q", val)
+      else:
+        sv = struct.pack("<I", val)
+      return " ".join("%02X" % ord(c) for c in sv)
+
+    def ptrfirst(self, val):
+      return FindBinary(0, SEARCH_CASE|SEARCH_DOWN, self.ptr_to_bytes(val))
+
+    def ptrnext(self, val, ref):
+      return FindBinary(ref+1, SEARCH_CASE|SEARCH_DOWN, self.ptr_to_bytes(val))
+
+    def xref_or_find(self, addr, allow_many = False):
+      lrefs = list(DataRefsTo(addr))
+      if len(lrefs) == 0:
+        lrefs = list(idautils.refs(addr, self.ptrfirst, self.ptrnext))
+      if len(lrefs) > 1 and not allow_many:
+          return []
+      lrefs = [r for r in lrefs if not isCode(GetFlags(r))]
+      return lrefs
+
+    def find_string(self, s, afrom=0):
+      ea = FindBinary(afrom, SEARCH_CASE|SEARCH_DOWN, '"' + s + '"')
+      return ea
+
+    def ForceDword(self, ea):
+      if ea != BADADDR and ea != 0:
+        if not isDwrd(GetFlags(ea)):
+          MakeUnknown(ea, 4, DOUNK_SIMPLE)
+          MakeDword(ea)
+        if isOff0(GetFlags(ea)) and GetFixupTgtType(ea) == -1:
+          # remove the offset
+          OpHex(ea, 0)
+
+    def ForceQword(self, ea):
+      if ea != BADADDR and ea != 0:
+        if not isQwrd(GetFlags(ea)):
+          MakeUnknown(ea, 8, DOUNK_SIMPLE)
+          MakeQword(ea)
+        if isOff0(GetFlags(ea)) and GetFixupTgtType(ea) == -1:
+          # remove the offset
+          OpHex(ea, 0)
+
+    def ForcePtr(self, ea, delta = 0):
+      if self.x64:
+        self.ForceQword(ea)
+      else:
+        self.ForceDword(ea)
+      if GetFixupTgtType(ea) != -1 and isOff0(GetFlags(ea)):
+        # don't touch fixups
+        return
+      pv = self.get_ptr(ea)
+      if pv != 0 and pv != BADADDR:
+        # apply offset again
+        if idaapi.is_spec_ea(pv):
+          delta = 0
+        OpOffEx(ea, 0, [REF_OFF32, REF_OFF64][self.x64], -1, 0, delta)
+
+# p pointer
+# v vtable pointer (delta ptrsize*2)
+# i integer (32-bit)
+# l integer (32 or 64-bit)
+    def format_struct(self, ea, fmt):
+      for f in fmt:
+        if f in ['p', 'v']:
+          if f == 'v':
+            delta = self.PTR_SIZE*2
+          else:
+            delta = 0
+          self.ForcePtr(ea, delta)
+          ea += self.PTR_SIZE
+        elif f == 'i':
+          self.ForceDword(ea)
+          ea += 4
+        elif f == 'l':
+          if self.x64:
+            self.ForceQword(ea)
+            ea += 8
+          else:
+            self.ForceDword(ea)
+            ea += 4
+      return ea
+
+    def force_name(self, ea, name):
+      if isTail(GetFlags(ea)):
+        MakeUnknown(ea, 1, DOUNK_SIMPLE)
+      MakeNameEx(ea, name, SN_NOWARN)
+
+    def is_bad_addr(self, ea):
+      return ea == 0 or ea == BADADDR or idaapi.is_spec_ea(ea) or not isLoaded(ea)
+
+    def vtname(self, name):
+      return "__ZTV" + name
+
+# sign extend b low bits in x
+# from "Bit Twiddling Hacks"
+    def SIGNEXT(self, x, b):
+        m = 1 << (b - 1)
+        x = x & ((1 << b) - 1)
+        return (x ^ m) - m
+
+    def xref_or_find(self, addr, allow_many = False):
+        lrefs = list(DataRefsTo(addr))
+        if len(lrefs) == 0:
+            lrefs = list(idautils.refs(addr, self.ptrfirst, self.ptrnext))
+        if len(lrefs) > 1 and not allow_many:
+            return []
+        lrefs = [r for r in lrefs if not isCode(GetFlags(r))]
+        return lrefs
+
+    def num2key(self, all_classes):
+        return [k for k in all_classes]
+
+    def add_missing_classes(self, classes):
+        missing = []
+        for c, parents in classes.iteritems():
+            for parent in parents:
+                if parent not in classes.keys():
+                    missing.append(parent)
+        for m in missing:
+            classes[m] = []


### PR DESCRIPTION
Hello, thank you for that awesome script.

I've think its possible to rename RTTI class member functions according to linux one if there same vtable size.

Also i fixed _get_xref_to_calls function:
```
            func = get_func(xref.frm)
            if (func is None):
                yield xref.to
            else:
                yield func.startEA
```
I think there was problem `xref.to` was always same as `ea` thats why `_multiple_xrefs_search` was not worked as excepted.

Also maybe rtti renamer function should be rewritted, but im not good at python atm :-)

Here's some results with current implementation on some client dll+so from Half-Life 1:
1. Found 670 (14.7%) functions in total! - no rtti rename
2. Found 1402 (30.8%) functions in total! - rtti vtable size match rename
3. Found 2452 (53.8%) functions in total! - rtti + dirty incorrect vtable size match rename

3 Is looks good but since vtables size mismatch i think in this case we can add some symbol before function like ```!!CBaseMonster::TraceAttack``` to indicate that function mb incorrect

RTTI scripts are from: https://github.com/nccgroup/SusanRTTI with little modification to scan vtable functions addresses